### PR TITLE
支持登陆用户本地持久化

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,4 @@ build/
 
 .VSCodeCounter/
 coverage/
+.vscode/

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,14 +1,20 @@
 {
-    // Use IntelliSense to learn about possible attributes.
-    // Hover to view descriptions of existing attributes.
-    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
-    "version": "0.2.0",
-    "configurations": [
-        {
-            "name": "Dart",
-            "type": "dart",
-            "request": "launch",
-            "program": "./test/query_test.dart"
-        }
-    ]
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Test",
+      "type": "dart",
+      "request": "launch",
+      "program": "./test/query_test.dart"
+    },
+    {
+      "name": "Example",
+      "type": "dart",
+      "request": "launch",
+      "program": "./example/lib/main.dart"
+    }
+  ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,16 +5,10 @@
   "version": "0.2.0",
   "configurations": [
     {
-      "name": "Test",
+      "name": "Dart",
       "type": "dart",
       "request": "launch",
       "program": "./test/query_test.dart"
-    },
-    {
-      "name": "Example",
-      "type": "dart",
-      "request": "launch",
-      "program": "./example/lib/main.dart"
     }
   ]
 }

--- a/lib/internal/http/lc_http_client.dart
+++ b/lib/internal/http/lc_http_client.dart
@@ -109,8 +109,9 @@ class _LCHttpClient {
     Digest digest = md5.convert(data);
     String sign = hex.encode(digest.bytes);
     headers['X-LC-Sign'] = '$sign,$timestamp';
-    if (LCUser.currentUser != null) {
-      headers['X-LC-Session'] = LCUser.currentUser.sessionToken;
+    LCUser currentUser = LCUser._currentUser;
+    if (currentUser != null) {
+      headers['X-LC-Session'] = currentUser.sessionToken;
     }
     return new Options(headers: headers);
   }

--- a/lib/internal/object/lc_object_data.dart
+++ b/lib/internal/object/lc_object_data.dart
@@ -34,4 +34,22 @@ class _LCObjectData {
     });
     return result;
   }
+
+  static Map<String, dynamic> encode(_LCObjectData objectData) {
+    if (objectData == null) {
+      return null;
+    }
+    Map<String, dynamic> data = {
+      'className': objectData.className,
+      'objectId': objectData.objectId,
+      'createdAt': objectData.createdAt.toString(),
+      'updatedAt': objectData.updatedAt.toString()
+    };
+    if (objectData.customPropertyMap != null) {
+      objectData.customPropertyMap.forEach((k, v) {
+        data[k] = _LCEncoder.encode(v);
+      });
+    }
+    return data;
+  }
 }

--- a/lib/internal/utils/lc_utils.dart
+++ b/lib/internal/utils/lc_utils.dart
@@ -57,3 +57,7 @@ String _twoDigits(int n) {
   if (n >= 10) return "$n";
   return "0$n";
 }
+
+bool isMobilePlatform() {
+  return Platform.isAndroid || Platform.isIOS;
+}

--- a/lib/leancloud.dart
+++ b/lib/leancloud.dart
@@ -8,6 +8,7 @@ import 'dart:math';
 import 'package:dio/dio.dart';
 import 'package:convert/convert.dart';
 import 'package:crypto/crypto.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 /// 编解码
 part 'internal/codec/lc_decoder.dart';

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -74,6 +74,11 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_web_plugins:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   http_parser:
     dependency: transitive
     description:
@@ -130,6 +135,34 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.5"
+  shared_preferences:
+    dependency: "direct main"
+    description:
+      name: shared_preferences
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.5.6+1"
+  shared_preferences_macos:
+    dependency: transitive
+    description:
+      name: shared_preferences_macos
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.0.1+4"
+  shared_preferences_platform_interface:
+    dependency: transitive
+    description:
+      name: shared_preferences_platform_interface
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.1"
+  shared_preferences_web:
+    dependency: transitive
+    description:
+      name: shared_preferences_web
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.2+3"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -200,3 +233,4 @@ packages:
     version: "3.5.0"
 sdks:
   dart: ">2.4.0 <3.0.0"
+  flutter: ">=1.12.13+hotfix.4 <2.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,6 +12,7 @@ dependencies:
   dio: ^3.0.8
   convert: ^2.1.1
   crypto: ^2.1.3
+  shared_preferences: ^0.5.6+1
 
 dev_dependencies:
   flutter_test:

--- a/test/acl_test.dart
+++ b/test/acl_test.dart
@@ -22,13 +22,14 @@ void main() {
     test('user read and write', () async {
       await LCUser.login('hello', 'world');
       LCObject account = new LCObject('Account');
-      LCACL acl = LCACL.createWithOwner(LCUser.currentUser);
+      LCUser currentUser = await LCUser.getCurrent();
+      LCACL acl = LCACL.createWithOwner(currentUser);
       account.acl = acl;
       account['balance'] = 512;
       await account.save();
 
-      assert(acl.getUserReadAccess(LCUser.currentUser) == true);
-      assert(acl.getUserWriteAccess(LCUser.currentUser) == true);
+      assert(acl.getUserReadAccess(currentUser) == true);
+      assert(acl.getUserWriteAccess(currentUser) == true);
 
       LCQuery<LCObject> query = new LCQuery('Account');
       LCObject result = await query.get(account.objectId);

--- a/test/role_test.dart
+++ b/test/role_test.dart
@@ -8,13 +8,13 @@ void main() {
     setUp(() => initNorthChina());
 
     test('new role', () async {
-      await LCUser.login('game', 'play');
+      LCUser currentUser = await LCUser.login('game', 'play');
       LCACL acl = new LCACL();
       acl.setPublicReadAccess(true);
-      acl.setUserWriteAccess(LCUser.currentUser, true);
+      acl.setUserWriteAccess(currentUser, true);
       String name = 'role_${DateTime.now().millisecondsSinceEpoch}';
       LCRole role = LCRole.create(name, acl);
-      role.addRelation('users', LCUser.currentUser);
+      role.addRelation('users', currentUser);
       await role.save();
     });
 

--- a/test/user_test.dart
+++ b/test/user_test.dart
@@ -30,7 +30,7 @@ void main() {
 
     test('login', () async {
       await LCUser.login('hello', 'world');
-      LCUser current = LCUser.currentUser;
+      LCUser current = await LCUser.getCurrent();
       assert(current.objectId != null);
       assert(!current.emailVerified);
       assert(!current.mobileVerified);
@@ -45,7 +45,7 @@ void main() {
 
     test('login by email', () async {
       await LCUser.loginByEmail('171253484@qq.com', 'world');
-      LCUser current = LCUser.currentUser;
+      LCUser current = await LCUser.getCurrent();
       assert(current.objectId != null);
     });
 
@@ -66,7 +66,7 @@ void main() {
     test('login by session token', () async {
       String sessionToken = 'luo2fpl4qij2050e7enqfz173';
       await LCUser.becomeWithSessionToken(sessionToken);
-      LCUser current = LCUser.currentUser;
+      LCUser current = await LCUser.getCurrent();
       assert(current.objectId != null);
     });
 
@@ -94,7 +94,7 @@ void main() {
     test('relate object', () async {
       await LCUser.loginByMobilePhoneNumber('15101006007', '112358');
       LCObject account = new LCObject('Account');
-      account['user'] = LCUser.currentUser;
+      account['user'] = await LCUser.getCurrent();
       await account.save();
     });
 
@@ -108,51 +108,52 @@ void main() {
         'openid': '${DateTime.now().millisecondsSinceEpoch}',
         'access_token': '${DateTime.now().millisecondsSinceEpoch}'
       };
-      await LCUser.loginWithAuthData(authData, 'weixin');
-      print(LCUser.currentUser.sessionToken);
-      assert(LCUser.currentUser.sessionToken != null);
-      String userId = LCUser.currentUser.objectId;
+      LCUser currentUser = await LCUser.loginWithAuthData(authData, 'weixin');
+      print(currentUser.sessionToken);
+      assert(currentUser.sessionToken != null);
+      String userId = currentUser.objectId;
       print('userId: $userId');
-      print(LCUser.currentUser.authData);
+      print(currentUser.authData);
 
-      LCUser.logout();
-      assert(LCUser.currentUser == null);
+      await LCUser.logout();
+      currentUser = await LCUser.getCurrent();
+      assert(currentUser == null);
 
-      await LCUser.loginWithAuthData(authData, 'weixin');
-      print(LCUser.currentUser.sessionToken);
-      assert(LCUser.currentUser.sessionToken != null);
-      assert(LCUser.currentUser.objectId == userId);
-      print(LCUser.currentUser.authData);
+      currentUser = await LCUser.loginWithAuthData(authData, 'weixin');
+      print(currentUser.sessionToken);
+      assert(currentUser.sessionToken != null);
+      assert(currentUser.objectId == userId);
+      print(currentUser.authData);
     });
 
     test('associate auth data', () async {
-      await LCUser.login('hello', 'world');
+      LCUser currentUser = await LCUser.login('hello', 'world');
       Map<String, dynamic> authData = {
         'expires_in': 7200,
         'openid': '${DateTime.now().millisecondsSinceEpoch}',
         'access_token': '${DateTime.now().millisecondsSinceEpoch}'
       };
-      await LCUser.currentUser.associateAuthData(authData, 'weixin');
-      print(LCUser.currentUser.authData);
-      print(LCUser.currentUser.authData['weixin']);
+      await currentUser.associateAuthData(authData, 'weixin');
+      print(currentUser.authData);
+      print(currentUser.authData['weixin']);
     });
 
     test('disassociate auth data', () async {
-      await LCUser.login('hello', 'world');
-      await LCUser.currentUser.disassociateWithAuthData('weixin');
+      LCUser currentUser = await LCUser.login('hello', 'world');
+      await currentUser.disassociateWithAuthData('weixin');
     });
 
     test('is authenticated', () async {
-      await LCUser.login('hello', 'world');
-      bool isAuthenticated = await LCUser.currentUser.isAuthenticated();
+      LCUser currentUser = await LCUser.login('hello', 'world');
+      bool isAuthenticated = await currentUser.isAuthenticated();
       print(isAuthenticated);
       assert(isAuthenticated);
     });
 
     test('update password', () async {
-      await LCUser.login('hello', 'world');
-      await LCUser.currentUser.updatePassword('world', 'newWorld');
-      await LCUser.currentUser.updatePassword('newWorld', 'world');
+      LCUser currentUser = await LCUser.login('hello', 'world');
+      await currentUser.updatePassword('world', 'newWorld');
+      await currentUser.updatePassword('newWorld', 'world');
     });
 
     test('login with auth data and union id', () async {
@@ -164,36 +165,37 @@ void main() {
       String unionId = '${DateTime.now().millisecondsSinceEpoch}';
       LCUserAuthDataLoginOption option = new LCUserAuthDataLoginOption();
       option.asMainAccount = true;
-      await LCUser.loginWithAuthDataAndUnionId(authData, 'weixin_app', unionId,
+      LCUser currentUser = await LCUser.loginWithAuthDataAndUnionId(
+          authData, 'weixin_app', unionId,
           option: option);
-      print(LCUser.currentUser.sessionToken);
-      assert(LCUser.currentUser.sessionToken != null);
-      String userId = LCUser.currentUser.objectId;
+      print(currentUser.sessionToken);
+      assert(currentUser.sessionToken != null);
+      String userId = currentUser.objectId;
       print('userId: $userId');
-      print(LCUser.currentUser.authData);
+      print(currentUser.authData);
 
-      LCUser.logout();
-      assert(LCUser.currentUser == null);
+      await LCUser.logout();
+      currentUser = await LCUser.getCurrent();
+      assert(currentUser == null);
 
-      await LCUser.loginWithAuthDataAndUnionId(
+      currentUser = await LCUser.loginWithAuthDataAndUnionId(
           authData, 'weixin_mini_app', unionId,
           option: option);
-      print(LCUser.currentUser.sessionToken);
-      assert(LCUser.currentUser.sessionToken != null);
-      assert(LCUser.currentUser.objectId == userId);
-      print(LCUser.currentUser.authData);
+      print(currentUser.sessionToken);
+      assert(currentUser.sessionToken != null);
+      assert(currentUser.objectId == userId);
+      print(currentUser.authData);
     });
 
     test('associate auth data with union id', () async {
-      await LCUser.login('hello', 'world');
+      LCUser currentUser = await LCUser.login('hello', 'world');
       Map<String, dynamic> authData = {
         'expires_in': 7200,
         'openid': '${DateTime.now().millisecondsSinceEpoch}',
         'access_token': '${DateTime.now().millisecondsSinceEpoch}'
       };
       String unionId = '${DateTime.now().millisecondsSinceEpoch}';
-      await LCUser.currentUser
-          .associateAuthDataAndUnionId(authData, 'qq', unionId);
+      await currentUser.associateAuthDataAndUnionId(authData, 'qq', unionId);
     });
   });
 }


### PR DESCRIPTION
由于 Future 的读写接口都是异步的，无法在 LCUser.currentUser 处同步加载本地持久化的数据。
之前 LCUser.currentUser 的 currentUser 直接暴露了 get/set 方法，考虑了一下，还是通过一个异步方法获取 currentUser 比较好。

```dart
LCUser currentUser = await LCUser.getCurrent();
```

引入了第三方库：shared_preferences，这个库只能运行在 android 和 ios 环境，所以没有响应单元测试。
在 iOS 和 Android 模拟器上已经测试通过。
