### PR TITLE
chore: limits the format of keys for Map type data

### DIFF
--- a/lib/internal/codec/lc_encoder.dart
+++ b/lib/internal/codec/lc_encoder.dart
@@ -56,6 +56,9 @@ class _LCEncoder {
   static dynamic encodeMap(Map map) {
     Map m = new Map();
     map.forEach((key, value) {
+      if (key.startsWith('_')) {
+        throw new ArgumentError('key should not start with \'_\'');
+      }
       m[key] = encode(value);
     });
     return m;


### PR DESCRIPTION
限制 Map 类型的字段不能以 _ 开头