### PR TITLE
调整 Map 类型数据 key 的限制

### DIFF
--- a/lib/internal/codec/lc_encoder.dart
+++ b/lib/internal/codec/lc_encoder.dart
@@ -56,9 +56,6 @@ class _LCEncoder {
   static dynamic encodeMap(Map map) {
     Map m = new Map();
     map.forEach((key, value) {
-      if (key.startsWith('_')) {
-        throw new ArgumentError('key should not start with \'_\'');
-      }
       m[key] = encode(value);
     });
     return m;

--- a/lib/lc_object.dart
+++ b/lib/lc_object.dart
@@ -3,7 +3,7 @@ part of leancloud_storage;
 /// LeanCloud Object
 ///
 /// Object is also called Record (in traditional relational databases)
-/// or Document (in some NoSQL databases). 
+/// or Document (in some NoSQL databases).
 class LCObject {
   /// The last known data for this object from cloud.
   _LCObjectData _data;
@@ -78,7 +78,11 @@ class LCObject {
     if (key.startsWith('_')) {
       throw new ArgumentError('key should not start with \'_\'');
     }
-    if (key == 'objectId' || key == 'createdAt' || key == 'updatedAt') {
+    if (key == 'objectId' ||
+        key == 'createdAt' ||
+        key == 'updatedAt' ||
+        key == 'className' ||
+        key == 'ACL') {
       throw new ArgumentError('$key is reserved by LeanCloud');
     }
     _LCSetOperation op = new _LCSetOperation(value);
@@ -108,7 +112,7 @@ class LCObject {
     _applyOperation(key, op);
   }
 
-  /// Removes relation [value] to [key]. 
+  /// Removes relation [value] to [key].
   void removeRelation(String key, LCObject value) {
     if (isNullOrEmpty(key)) {
       throw ArgumentError.notNull('key');
@@ -129,7 +133,7 @@ class LCObject {
     _applyOperation(key, op);
   }
 
-  /// Atomically decrements the value of the given [key] with [amount]. 
+  /// Atomically decrements the value of the given [key] with [amount].
   void decrement(String key, num amount) {
     if (isNullOrEmpty(key)) {
       throw ArgumentError.notNull('key');
@@ -215,7 +219,7 @@ class LCObject {
   }
 
   /// Refreshes the attributes.
-  /// 
+  ///
   /// This populates attributes by starting with the last known data from the
   /// server, and applying all of the local changes that have been made since
   /// then.
@@ -269,7 +273,7 @@ class LCObject {
   }
 
   /// Fetches the object from the cloud.
-  /// 
+  ///
   /// Can also specifies which [keys] to fetch,
   /// and if this [includes] pointed objects.
   Future<LCObject> fetch(
@@ -378,7 +382,7 @@ class LCObject {
   }
 
   /// Saves the object to the cloud.
-  /// 
+  ///
   /// Can also specify whether to [fetchWhenSave],
   /// or only saving the object when it matches the [query].
   Future<LCObject> save(
@@ -441,7 +445,7 @@ class LCObject {
     await LeanCloud._httpClient.delete(path);
   }
 
-  /// Serializes this [LCObject] to a JSON string. 
+  /// Serializes this [LCObject] to a JSON string.
   String toString() {
     return jsonEncode(_LCObjectData.encode(_data));
   }

--- a/lib/lc_user.dart
+++ b/lib/lc_user.dart
@@ -256,7 +256,8 @@ class LCUser extends LCObject {
     this.authData = {authType: data};
     try {
       await super.save();
-      this.authData.addAll(oriAuthData);
+      oriAuthData.addAll(this.authData);
+      _updateAuthData(oriAuthData);
       await _saveToLocal();
     } on Exception catch (e) {
       this.authData = oriAuthData;
@@ -270,12 +271,18 @@ class LCUser extends LCObject {
     try {
       await super.save();
       oriAuthData.remove(authType);
-      this.authData = oriAuthData;
+      _updateAuthData(oriAuthData);
       await _saveToLocal();
     } on Exception catch (e) {
       this.authData = oriAuthData;
       throw e;
     }
+  }
+
+  void _updateAuthData(Map oriAuthData) {
+    _LCObjectData objData = new _LCObjectData();
+    objData.customPropertyMap['authData'] = oriAuthData;
+    _merge(objData);
   }
 
   /// Creates an anonymous user.
@@ -436,6 +443,7 @@ class LCUser extends LCObject {
     try {
       SharedPreferences prefs = await SharedPreferences.getInstance();
       String userData = prefs.getString(CurrentUserKey);
+      LCLogger.debug(userData);
       _LCObjectData objectData = _LCObjectData.decode(jsonDecode(userData));
       _currentUser = LCUser._fromObjectData(objectData);
     } on Error catch (e) {


### PR DESCRIPTION
## 相关工单

[登录后，关闭app 再打开app，需要重新登录](https://www.leanticket.cn/tickets/37278)

调查发现，由于在序列化数据时，限制 Map 类型不能使用 _ 开头的 key，导致 authData 中的 _weixin_unionid 序列化失败，没有持久化到本地导致。

## 讨论结果

- Object 字段限制：_ 开头，objectId，className，ACL，createdAt，uptdatedAt
- Map key 限制：无