### PR TITLE
fix: LCFile#acl

### DIFF
--- a/lib/lc_file.dart
+++ b/lib/lc_file.dart
@@ -121,16 +121,13 @@ class LCFile extends LCObject {
   Future<Map> _getUploadToken() async {
     Map<String, dynamic> data = {
       'name': name,
-      'key': _newUUID(),
       '__type': 'File',
       'mime_type': mimeType,
-      'metaData': metaData
+      'metaData': metaData,
     };
+    if (acl != null) {
+      data['ACL'] = _LCEncoder.encodeACL(acl);
+    }
     return await LeanCloud._httpClient.post('fileTokens', data: data);
-  }
-
-  String _newUUID() {
-    _LCUuid uuid = new _LCUuid();
-    return uuid.generateV4();
   }
 }

--- a/test/file_test.dart
+++ b/test/file_test.dart
@@ -78,6 +78,24 @@ void main() {
         });
       });
     });
+    
+    test('file acl', () async {
+      LCUser user = await LCUser.loginAnonymously();
+
+      LCFile file = await LCFile.fromPath('avatar', './avatar.jpg');
+      LCACL acl = new LCACL();
+      acl.setUserReadAccess(user, true);
+      file.acl = acl;
+      await file.save();
+
+      LCQuery<LCFile> query = new LCQuery(LCFile.ClassName);
+      LCFile avatar = await query.get(file.objectId);
+      assert(avatar.objectId != null);
+
+      await LCUser.loginAnonymously();
+      LCFile forbiddenAvatar = await query.get(file.objectId);
+      assert(forbiddenAvatar == null);
+    });
   });
 
   group('file in US', () {


### PR DESCRIPTION
## 相关工单

https://www.leanticket.cn/tickets/37679

## 补充

LCFile 的属性在 /filetokens 时传入（且只支持特定属性，并不支持更新），之前的逻辑漏掉了 ACL