### PR TITLE
fix: save user to disk.

### DIFF
--- a/lib/lc_user.dart
+++ b/lib/lc_user.dart
@@ -69,9 +69,7 @@ class LCUser extends LCObject {
     if (objectId != null) {
       throw ArgumentError('Cannot sign up a user that already exists.');
     }
-    await super.save();
-    _currentUser = this;
-    await _saveToLocal();
+    _currentUser = await save();
     return this;
   }
 
@@ -552,5 +550,12 @@ class LCUser extends LCObject {
     String path = 'changePhoneNumber';
     Map<String, dynamic> data = {'mobilePhoneNumber': mobile, 'code': code};
     await LeanCloud._httpClient.post(path, data: data);
+  }
+
+  @override
+  Future<LCObject> save({bool fetchWhenSave = false, LCQuery<LCObject> query}) async {
+    _currentUser = await super.save(fetchWhenSave: fetchWhenSave, query: query);
+    await _saveToLocal();
+    return this;
   }
 }


### PR DESCRIPTION
## 相关帖子

[Flutter 修改用户信息后不能同步修改本地缓存](https://forum.leancloud.cn/t/flutter/24201)

## 修改方案

重载 LCUser#save()，在 save 成功后同步到本地