### PR TITLE
add: Initialize with masterKey

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,23 @@ import 'package:leancloud_storage/leancloud.dart';
 
 ## Initialize
 
+Initialize with appKey:
+
 ```dart
 LeanCloud.initialize(
   APP_ID, APP_KEY,
   server: APP_SERVER, // to use your own custom domain
+  queryCache: new LCQueryCache() // optinoal, enable cache
+);
+```
+
+Initialize with masterKey:
+
+```dart
+LeanCloud.initialize(
+  APP_ID, APP_KEY,
+  server: APP_SERVER, // to use your own custom domain
+  masterKey: MASTER_KEY, // use masterKey
   queryCache: new LCQueryCache() // optinoal, enable cache
 );
 ```

--- a/lib/leancloud.dart
+++ b/lib/leancloud.dart
@@ -93,7 +93,7 @@ class LeanCloud {
 
   /// Initialization
   static void initialize(String appId, String appKey,
-      {String? server, LCQueryCache? queryCache}) {
+      {String? server, String? masterKey, LCQueryCache? queryCache}) {
     if (isNullOrEmpty(appId)) {
       throw new ArgumentError.notNull('appId');
     }
@@ -110,8 +110,13 @@ class LeanCloud {
     LCObject.registerSubclass<LCFriendshipRequest>(
         LCFriendshipRequest.ClassName, () => new LCFriendshipRequest());
 
-    _httpClient = new _LCHttpClient(
-        appId, appKey, server, SDKVersion, APIVersion, queryCache);
+    if (masterKey != null) {
+      _httpClient = new _LCHttpClient(
+          appId, masterKey, server, SDKVersion, APIVersion, true, queryCache);
+    } else {
+      _httpClient = new _LCHttpClient(
+          appId, appKey, server, SDKVersion, APIVersion, false, queryCache);
+    }
   }
 
   static Future<bool> clearAllCache() {


### PR DESCRIPTION
Storage SDK for Flutter cannot initialize with masterKey in the current version. Followed by the doc of REST API(https://leancloud.cn/docs/rest_api.html), I modified the method of initializing so that it can now initialize with masterKey.